### PR TITLE
remove "output/" prefix from manifest file

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -7,5 +7,5 @@ applications:
 - services:
   - tradeoff-analytics-service
   name: nests
-  path: output/webApp.war
+  path: webApp.war
   memory: 512M


### PR DESCRIPTION
build script is storing files in /output folder, then your build job is configured to persist content of /output folder only.
Thus, the deployer will find the war file at the root of the artifacts, not under output/webApp.war.
